### PR TITLE
Fix: ensure getCurrentBalance uses latest('id') for correct ordering

### DIFF
--- a/src/Traits/HasCredits.php
+++ b/src/Traits/HasCredits.php
@@ -83,8 +83,9 @@ trait HasCredits
      */
     public function getCurrentBalance(): float
     {
+       // Use latest by ID to ensure correct order even with same timestamps
         return $this->creditTransactions()
-            ->latest()
+            ->latest('id')
             ->value('running_balance') ?? 0.0;
     }
 

--- a/tests/HasCreditsTest.php
+++ b/tests/HasCreditsTest.php
@@ -185,3 +185,14 @@ it('dispatches event when credits are transferred', function () {
             && $event->metadata === ['type' => 'gift'];
     });
 });
+it('returns correct running balance even when multiple transactions share same timestamp', function () {
+
+    // Add credits first
+    $this->user->addCredits(100, 'Initial');
+
+    for ($i = 0; $i < 3; $i++) {
+        $this->user->deductCredits(10, 'Loop deduction');
+    }
+
+    expect($this->user->getCurrentBalance())->toBe(70.0);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit balance calculation accuracy when multiple transactions occur simultaneously, ensuring reliable balance reporting even when transactions share identical timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->