### PR TITLE
fix: deterministic queries on getBalanceAsOf

### DIFF
--- a/src/Traits/HasCredits.php
+++ b/src/Traits/HasCredits.php
@@ -157,7 +157,7 @@ trait HasCredits
 
         return $this->creditTransactions()
             ->where('created_at', '<=', $dateTime)
-            ->latest()
+            ->latest('id')
             ->value('running_balance') ?? 0.0;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic balance calculations when multiple transactions share identical timestamps, ensuring consistent results across database engines.

* **Tests**
  * Added tests to verify deterministic ordering behavior for balance calculations with simultaneous transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->